### PR TITLE
rm calls to logging.basicConfig

### DIFF
--- a/richkit/analyse/segment.py
+++ b/richkit/analyse/segment.py
@@ -3,9 +3,7 @@ import requests
 import os
 from richkit.analyse.util import temp_directory
 import logging
-logging.basicConfig(format='%(asctime)s %(name)-12s %(levelname)-8s %(message)s',
-                    datefmt='%m-%d %H:%M',
-                    level=logging.DEBUG)
+
 logger = logging.getLogger(__name__)
 
 class OneGramDist(dict):

--- a/richkit/analyse/util.py
+++ b/richkit/analyse/util.py
@@ -3,9 +3,7 @@ import requests
 import tempfile
 import sys
 import logging
-logging.basicConfig(format='%(asctime)s %(name)-12s %(levelname)-8s %(message)s',
-                    datefmt='%m-%d %H:%M',
-                    level=logging.DEBUG)
+
 logger = logging.getLogger(__name__)
 temp_directory = tempfile.mkdtemp()
 

--- a/richkit/lookup/util.py
+++ b/richkit/lookup/util.py
@@ -3,9 +3,7 @@ import os, subprocess
 import time, calendar, shutil
 import tempfile
 import logging
-logging.basicConfig(format='%(asctime)s %(name)-12s %(levelname)-8s %(message)s',
-                    datefmt='%m-%d %H:%M',
-                    level=logging.DEBUG)
+
 logger = logging.getLogger(__name__)
 temp_directory = tempfile.mkdtemp()
 

--- a/richkit/retrieve/dns.py
+++ b/richkit/retrieve/dns.py
@@ -2,9 +2,6 @@ from dns import reversename
 from dns import resolver
 import logging
 
-logging.basicConfig(format='%(asctime)s %(name)-12s %(levelname)-8s %(message)s',
-                    datefmt='%m-%d %H:%M',
-                    level=logging.DEBUG)
 logger = logging.getLogger(__name__)
 
 

--- a/richkit/retrieve/util.py
+++ b/richkit/retrieve/util.py
@@ -3,9 +3,7 @@ from bs4 import BeautifulSoup, NavigableString
 import whois
 import sys
 import logging
-logging.basicConfig(format='%(asctime)s %(name)-12s %(levelname)-8s %(message)s',
-                    datefmt='%m-%d %H:%M',
-                    level=logging.DEBUG) ## default logging level is WARNING, making it DEBUG !
+
 logger = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
fixes #53

The reational is that because richkit is a library, we should not
decide what log messages to print to stdout, but leave that to whatever
application uses richkit. Removed calls to `logging.basicConfig`
bacause that sets up the entire loggin facility and prints to stdout -
also for messages from modules we use.