### PR TITLE
Feature/clean up some merging 20200228

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -71,8 +71,7 @@ jobs:
       run: |
         cd docs
         make coverage
-        python -c "from pathlib import Path; print(Path('_build/coverage/python.txt').read_text())"
-        coverage report --fail-under=79
+        python -c "from pathlib import Path; print(Path('_build/coverage/python.txt').read_text())" # this prints dosctring coverage report
     - name: Build documentation
       run: |
         pip install sphinx

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -53,19 +53,6 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r requirements.txt
 
-
-    - name: Lint with flake8
-      run: |
-        pip install flake8
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-        bash -c "pip install \
-          coverage \
-          pytest \
-        "
-
     - name: Test with pytest
       env:
         MAXMIND_LICENSE_KEY: ${{ secrets.MAXMIND_LICENSE_KEY }}

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -73,7 +73,7 @@ jobs:
         make doctest
     - name: Documentation coverage
       env:
-        MAXMIND_LICENSE_KEY: DUMMY: A valid license is not needed here
+        MAXMIND_LICENSE_KEY: "DUMMY: A valid license is not needed here"
       run: |
         cd docs
         make coverage

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -53,9 +53,9 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
-        pip install \\
-            coverage \\
-            pytest \\
+        pip install \
+            coverage \
+            pytest \
             sphinx
 
     - name: Test with pytest

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -62,7 +62,7 @@ jobs:
       env:
         MAXMIND_LICENSE_KEY: ${{ secrets.MAXMIND_LICENSE_KEY }}
       run: |
-        pytest
+        coverage run --source=richkit -m pytest
     - name: Coverage report
       run: |
         coverage report --fail-under=79

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -33,6 +33,7 @@ jobs:
             false
         fi
         echo "Number of validation errors from flake8 is: $FLAKE8_ERROR_CNT (Limit is: $FLAKE8_ERROR_LIMIT)"
+
   test:
     runs-on: ${{ matrix.os }}
     strategy:
@@ -52,6 +53,10 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
+        pip install \\
+            coverage \\
+            pytest \\
+            sphinx
 
     - name: Test with pytest
       env:
@@ -74,6 +79,5 @@ jobs:
         python -c "from pathlib import Path; print(Path('_build/coverage/python.txt').read_text())" # this prints dosctring coverage report
     - name: Build documentation
       run: |
-        pip install sphinx
         cd docs
         make html

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -72,6 +72,8 @@ jobs:
         cd docs
         make doctest
     - name: Documentation coverage
+      env:
+        MAXMIND_LICENSE_KEY: DUMMY: A valid license is not needed here
       run: |
         cd docs
         make coverage

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -53,10 +53,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
-        pip install \
-            coverage \
-            pytest \
-            sphinx
+        pip install coverage pytest sphinx
 
     - name: Test with pytest
       env:

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -68,6 +68,8 @@ jobs:
         coverage report --fail-under=79
  
     - name: Doctest
+      env:
+        MAXMIND_LICENSE_KEY: ${{ secrets.MAXMIND_LICENSE_KEY }}
       run: |
         python -m doctest -v README.md
         cd docs

--- a/README.md
+++ b/README.md
@@ -85,41 +85,9 @@ Richkit define a set of functions categorized by the following modules:
 
 - `richkit.analyse`: This module provides functions that can be applied to a domain  name. Similarly to `richkit.lookup`, and in contrast to `richkit.retrieve`, this is done without disclosing the domain name to third parties and breaching confidentiality.
 
-- Retriving effective top level domain of a given url: 
-  
-      ```python3
-      from richkit.analyse import tld
-
-      urls = ["www.aau.dk","www.github.com","www.google.com"]
-
-      for url in urls:
-         print(tld(url))
-      ```
-- Retriving category of a given url : 
-
-   ```python3
-   from richkit.retrieve.symantec import fetch_from_internet
-   from richkit.retrieve.symantec import LocalCategoryDB
-
-   urls = ["www.aau.dk","www.github.com","www.google.com"]
-
-   local_db = LocalCategoryDB()
-   for url in urls:
-      url_category=local_db.get_category(url)
-      if url_category=='':
-         url_category=fetch_from_internet(url)
-      print(url_category)
-   ```
-
-
-Richkit define a set of functions categorized by the following modules:
-
 - `richkit.analyse`: This module provides functions that can be applied to a domain  name. Similarly to `richkit.lookup`, and in contrast to `richkit.retrieve`, this is done without disclosing the domain name to third parties and breaching confidentiality.
 
-
-
 - `richkit.lookup`: This modules provides the ability to look up domain names in local resources, i.e. the domain name cannot be sent of to third parties. The module might fetch resources, such as lists or databasese, but this must be done in a way that keeps the domain name confidential. Contrast this with `richkit.retrieve`.
-
 
 - `richkit.retrieve`: This module provides the ability to retrieve data on domain names of any sort. It comes without the "confidentiality contract" of `richkit.lookup`.
 

--- a/richkit/test/retrieve/test_urlvoid.py
+++ b/richkit/test/retrieve/test_urlvoid.py
@@ -73,7 +73,6 @@ class URLVoidTestCase(unittest.TestCase):
         #     "Failed to reject ASN 0xFFFFFFFF + 0x1 (RFC 6793 max value + 1)",
         # )
 
-    @unittest.expectedFailure
     def test_blacklist_status(self):
         for k, v in self.test_urls.items():
             instance = URLVoid(k)


### PR DESCRIPTION
Some of recently merged pull requests appears to have unintentionally reverted changed from previous merged PRs, removing inteded changes and duplicating some chunks, and placing them in odd positions. This motivates the majority of commits.

b0a3751 is included to fix that an unstable test, against a public API, is now working, but expect this to go back to fail at any time. This is to be addresses in #77 