### PR TITLE
removing logging.basicConfig

### DIFF
--- a/richkit/analyse/segment.py
+++ b/richkit/analyse/segment.py
@@ -3,9 +3,7 @@ import requests
 import os
 from richkit.analyse.util import temp_directory
 import logging
-logging.basicConfig(format='%(asctime)s %(name)-12s %(levelname)-8s %(message)s',
-                    datefmt='%m-%d %H:%M',
-                    level=logging.DEBUG)
+
 logger = logging.getLogger(__name__)
 
 class OneGramDist(dict):

--- a/richkit/analyse/util.py
+++ b/richkit/analyse/util.py
@@ -3,9 +3,7 @@ import requests
 import tempfile
 import sys
 import logging
-logging.basicConfig(format='%(asctime)s %(name)-12s %(levelname)-8s %(message)s',
-                    datefmt='%m-%d %H:%M',
-                    level=logging.DEBUG)
+
 logger = logging.getLogger(__name__)
 temp_directory = tempfile.mkdtemp()
 

--- a/richkit/lookup/util.py
+++ b/richkit/lookup/util.py
@@ -5,9 +5,6 @@ import tempfile
 import logging
 from pathlib import Path
 
-logging.basicConfig(format='%(asctime)s %(name)-12s %(levelname)-8s %(message)s',
-                    datefmt='%m-%d %H:%M',
-                    level=logging.DEBUG)
 """
 Lookups in the MaxMind GeoLite2 databases.
 

--- a/richkit/retrieve/dns.py
+++ b/richkit/retrieve/dns.py
@@ -2,9 +2,6 @@ from dns import reversename
 from dns import resolver
 import logging
 
-logging.basicConfig(format='%(asctime)s %(name)-12s %(levelname)-8s %(message)s',
-                    datefmt='%m-%d %H:%M',
-                    level=logging.DEBUG)
 logger = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
fixes #53 

The rationale is that because richkit is a library, we should not
decide what log messages to print to stdout, but leave that to whatever
application uses richkit. Removed calls to logging.basicConfig
bacause that sets up the entire loggin facility and prints to stdout -
also for messages from modules we use.

(This is another, hopefully final, take on the previous PRs #82 #84  and #85 , due rebasing onto `develop`)