### PR TITLE
docs updated failing test for blacklist status check removed

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,4 +1,4 @@
-Welcome to rickit's documentation!
+Welcome to richkit's documentation!
 ==================================
 
 .. automodule:: richkit

--- a/richkit/__init__.py
+++ b/richkit/__init__.py
@@ -1,7 +1,7 @@
-"""dat is the Domain Analysis Toolkit
+"""richkit is the Domain Enrichment Kit
 
 See the `README
-<https://github.com/aau-network-security/domain-analysis-toolkit/blob/master/README.md>`_
+<https://github.com/aau-network-security/richkit/blob/master/README.md>`_
 for a general introduction.
 
 """

--- a/richkit/retrieve/urlvoid.py
+++ b/richkit/retrieve/urlvoid.py
@@ -65,7 +65,7 @@ class URLVoid(object):
     def blacklist_status(self):
         """
 
-        :return: Blacklist status among 36 services which are enable
+        :return: Blacklist status among 36 services or more which are enable
         in URLVOID itself.
         """
         try:

--- a/richkit/test/retrieve/test_urlvoid.py
+++ b/richkit/test/retrieve/test_urlvoid.py
@@ -7,6 +7,8 @@ class URLVoidTestCase(unittest.TestCase):
     test_urls = {
         "google.co.uk": {
             "domain_registration": "1999-02-14",
+            # checking number of blacklist status is not required, because the number of services where URLvoid uses may change over time.
+            # therefore, the test has been removed
             "blacklist_status": "0/36",
             "ASN": "AS15169",
             "server_location": " (US) United States",
@@ -72,11 +74,6 @@ class URLVoidTestCase(unittest.TestCase):
         #     StubURLVoid('AS4294967295').get_asn(),
         #     "Failed to reject ASN 0xFFFFFFFF + 0x1 (RFC 6793 max value + 1)",
         # )
-
-    def test_blacklist_status(self):
-        for k, v in self.test_urls.items():
-            instance = URLVoid(k)
-            assert instance.blacklist_status() == v["blacklist_status"]
 
 
 if __name__ == '__main__':

--- a/richkit/test/retrieve/test_urlvoid.py
+++ b/richkit/test/retrieve/test_urlvoid.py
@@ -1,14 +1,12 @@
 from richkit.retrieve.urlvoid import URLVoid
 
-import unittest
+import unittest,re
 
 
 class URLVoidTestCase(unittest.TestCase):
     test_urls = {
         "google.co.uk": {
             "domain_registration": "1999-02-14",
-            # checking number of blacklist status is not required, because the number of services where URLvoid uses may change over time.
-            # therefore, the test has been removed
             "blacklist_status": "0/36",
             "ASN": "AS15169",
             "server_location": " (US) United States",
@@ -75,6 +73,11 @@ class URLVoidTestCase(unittest.TestCase):
         #     "Failed to reject ASN 0xFFFFFFFF + 0x1 (RFC 6793 max value + 1)",
         # )
 
+    def test_blacklist_status(self):
+        for k, v in self.test_urls.items():
+            instance = URLVoid(k)
+            blacklist_status = instance.blacklist_status()
+            assert re.match(r'[0]/\d*',blacklist_status)
 
 if __name__ == '__main__':
     unittest.main()

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open(path.join(root, 'README.md'), encoding='utf-8') as f:
 
 setuptools.setup(
     name='richkit',
-    description='Domain analysis toolkit',
+    description='Domain enrichment kit ',
     version='latest',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
- docs updated 
- ~blacklist status check removed (because the number of services URLVoid might change over time, and fetching it dynamically instead of putting it as string contradicts the point of having test)~
- regex inserted instead of removing function.

