### PR TITLE
add missing test case

### DIFF
--- a/richkit/lookup/__init__.py
+++ b/richkit/lookup/__init__.py
@@ -10,7 +10,7 @@ from richkit.lookup import geo
 
 
 def country(ip_address):
-    """"
+    """
     Return the country code of a given IP Address
 
     :param ip_address: IP Address (string)
@@ -18,9 +18,17 @@ def country(ip_address):
     return geo.get_country(ip_address)
 
 def asn(ip_address):
-    """"
+    """
     Return the Autonomous System Number of a given IP Address
 
     :param ip_address: IP Address (string)
     """
     return geo.get_asn(ip_address)
+
+def registered_country(ip_address):
+    """
+    Return the registered country code of a given IP Address
+
+    :param ip_address: IP Address (string)
+    """
+    return geo.get_registered_country(ip_address)

--- a/richkit/test/lookup/test_geo.py
+++ b/richkit/test/lookup/test_geo.py
@@ -11,3 +11,7 @@ class LookupTestCase(unittest.TestCase):
     def test_asn(self):
         asn = lookup.asn("8.8.8.8")
         assert asn == 'AS15169'
+
+    def test_registered_country(self):
+        registered_country = lookup.registered_country("8.8.8.8")
+        assert registered_country == 'US'


### PR DESCRIPTION
- missing test case added however it has no affect to coverage result. 
- I have checked `anaylse.py` and apparently, all testable functions are tested.
- As seen in given SS below, %73  lines already covered which means, test case visited %73 of `analyse.py` file, the rest belongs to skipped test cases. 

<img width="428" alt="Screenshot 2020-03-19 at 18 51 56" src="https://user-images.githubusercontent.com/13614433/77086348-b5c89b00-6a12-11ea-94b2-c05c42cbc3a4.png">

- I could not entirely understand why it is %51 in `Test with pytest` step over [here](https://github.com/aau-network-security/richkit/runs/519340164)

