### PR TITLE
check env_variable, pring warning to user

### DIFF
--- a/richkit/lookup/__init__.py
+++ b/richkit/lookup/__init__.py
@@ -34,3 +34,13 @@ def registered_country(ip_address):
     :param ip_address: IP Address (string)
     """
     return geo.get_registered_country(ip_address)
+
+def maxmindb_licence_key(license_key):
+    """
+    Return license key for MaxMind DB
+    Retrieve license key for usage of MaxMindDb
+
+    If it is not present print warning
+    """
+
+    return geo.get_license_key(license_key)

--- a/richkit/lookup/geo.py
+++ b/richkit/lookup/geo.py
@@ -2,6 +2,24 @@ from richkit.lookup.util import MaxMindDB
 import os
 
 
+def get_license_key(license_key='MAXMIND_LICENSE_KEY'):
+    """
+    @param license_key: Name of environment variable
+    @return: license of MaxMindDB from environent variables as string
+    @return: in case of error, returns Exception, more specifically KeyError
+    """
+    try:
+        maxmind_db_license = os.environ[license_key]
+        return maxmind_db_license
+    except Exception:
+        print("\nWARNING: No MAXMIND LICENSE KEY Found in environment variables")
+        print("\nUsage of lookup module might be affected due to no MaxMind DB License".strip())
+        print("\nMore info ? Check here: https://github.com/aau-network-security/richkit/wiki/Retrieve-and-configure"
+              "-licence-key".strip())
+        print("Proceeding anyway...")
+        return 'NOLICENSEKEYFOUND'
+
+
 def get_country(ip_address):
     """
     Return the country code of a given IP address
@@ -9,6 +27,7 @@ def get_country(ip_address):
     :param ip_address: IP Address (string)
 
     """
+
     try:
         country_code_db = MaxMindDB((
             "https://download.maxmind.com/app/geoip_download?"

--- a/richkit/lookup/geo.py
+++ b/richkit/lookup/geo.py
@@ -35,7 +35,7 @@ def get_country(ip_address):
             "license_key={license_key}&"
             "suffix=tar.gz"
         ).format(
-            license_key=os.environ['MAXMIND_LICENSE_KEY'],
+            license_key=get_license_key(),
         ), "cc"
         )
         result = country_code_db.get_data(ip_address)
@@ -59,7 +59,7 @@ def get_registered_country(ip_address):
             "license_key={license_key}&"
             "suffix=tar.gz"
         ).format(
-            license_key=os.environ['MAXMIND_LICENSE_KEY'],
+            license_key=get_license_key(),
         ), "cc"
         )
         result = country_code_db.get_data(ip_address)
@@ -83,7 +83,7 @@ def get_asn(ip_address):
             "license_key={license_key}&"
             "suffix=tar.gz"
         ).format(
-            license_key=os.environ['MAXMIND_LICENSE_KEY'],
+            license_key=get_license_key(),
         ), "asn"
         )
         result = country_code_db.get_data(ip_address)

--- a/richkit/test/lookup/test_geo.py
+++ b/richkit/test/lookup/test_geo.py
@@ -1,3 +1,5 @@
+import os
+
 from richkit import lookup
 import unittest
 
@@ -15,3 +17,10 @@ class LookupTestCase(unittest.TestCase):
     def test_registered_country(self):
         registered_country = lookup.registered_country("8.8.8.8")
         assert registered_country == 'US'
+
+    def test_maxmindb_licence_key(self):
+        test_license_key = os.environ["TEST_LICENSE_KEY"] = "LICENSEKEY"
+        license_key = lookup.maxmindb_licence_key("TEST_LICENSE_KEY")
+        non_existing_license_key = lookup.maxmindb_licence_key("NON-EXISTING")
+        self.assertTrue(license_key, test_license_key)
+        self.assertIs(non_existing_license_key, 'NOLICENSEKEYFOUND')


### PR DESCRIPTION
- check to environment variable for maxmind db added, 
- warning to user added (without using `warning` library of python)
   - `warning` library could be used in future however now, I do not want to add one more library            
         to requirements, (but if you are thinking it is important to add at this stage, I can)
- wiki page created on how to retrieve maxmind db license key and set it. [here](https://github.com/aau-network-security/richkit/wiki/Retrieve-and-configure-licence-key) (Feel free to modify and more details if you see it not enough)
- test case regarding to retrieving environment variable called `MAXMIND_LICENCE_KEY` added

